### PR TITLE
fix: spec fixes

### DIFF
--- a/loyaltypoints/app/controllers/points_controller.rb
+++ b/loyaltypoints/app/controllers/points_controller.rb
@@ -87,6 +87,9 @@ class PointsController < ApplicationController
     if histories.none?
       render status: :not_found
     else
+      histories = histories.map do |h|
+        h.as_json.deep_transform_keys{ |k| k.camelize(:lower) }
+      end
       render json: histories
     end
   end

--- a/loyaltypoints/test/controllers/points_controller_test.rb
+++ b/loyaltypoints/test/controllers/points_controller_test.rb
@@ -27,26 +27,26 @@ class PointsControllerTest < ActionDispatch::IntegrationTest
   test "invalid balance redemption" do
     # User 1 has 100 points by default, an amount of 20 is equivalent to
     # 20 * 100 = 200 points and is thus invalid redemption amount.
-    post "/points/redeem/1", params: { points: 20 }
+    post "/points/redeem/1", params: { amount: 20 }
     assert_response 400
     body = JSON.parse(response.body)
     assert_equal(I18n.t("invalid_points"), body["error_message"])
   end
 
   test "valid balance redemption" do
-    post "/points/redeem/1", params: { points: 10 }
+    post "/points/redeem/1", params: { amount: 10 }
     assert_response 200
   end
 
   test "invalid balance addition" do
-    post "/points/add/1", params: { points: -13234 }
+    post "/points/add/1", params: { amount: -13234 }
     assert_response 400
     body = JSON.parse(response.body)
     assert_equal(I18n.t("invalid_balance"), body["error_message"])
   end
 
   test "valid balance addition" do
-    post "/points/add/1", params: { points: 1000 }
+    post "/points/add/1", params: { amount: 1000 }
     assert_response :success
   end
 
@@ -64,7 +64,7 @@ class PointsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     body = JSON.parse(response.body).first
-    assert_equal(body["starting_balance"], 100)
-    assert_equal(body["ending_balance"], 20)
+    assert_equal(body["startingBalance"], 100)
+    assert_equal(body["endingBalance"], 20)
   end
 end


### PR DESCRIPTION
A fix for one of the unit tests: parameter is called "amount" not points.
Also, camel casing the return from `transactions` action to ensure that frontend doesn't need to transform to camel case.